### PR TITLE
Fixes build error (missing context argument)

### DIFF
--- a/gist.go
+++ b/gist.go
@@ -91,7 +91,7 @@ func main() {
 	client := github.NewClient(
 		oauth2.NewClient(oauth2.NoContext, &ts),
 	)
-	gist, _, err := client.Gists.Create(&github.Gist{
+	gist, _, err := client.Gists.Create(nil, &github.Gist{
 		Files:  files,
 		Public: &public,
 	})


### PR DESCRIPTION
Fixes:

```#!bash
$ go build .
# github.com/icholy/gist
./gist.go:94:37: not enough arguments in call to client.Gists.Create
	have (*github.Gist)
	want (context.Context, *github.Gist)
```